### PR TITLE
Potential fix for code scanning alert no. 3: URL redirection from remote source

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]

--- a/whispers/views.py
+++ b/whispers/views.py
@@ -1,8 +1,8 @@
 import ipaddress
 import logging
-from urllib.parse import urlencode
 
 from django.conf import settings
+from django.contrib.auth.views import redirect_to_login
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.utils.http import url_has_allowed_host_and_scheme
@@ -94,7 +94,7 @@ def _redirect_to_login(request):
         require_https=request.is_secure(),
     ):
         next_path = "/"
-    return redirect(f"{login_url}?{urlencode({'next': next_path})}")
+    return redirect_to_login(next_path, login_url=login_url)
 
 
 def _first_error(errors):

--- a/whispers/views.py
+++ b/whispers/views.py
@@ -1,9 +1,11 @@
 import ipaddress
 import logging
+from urllib.parse import urlencode
 
 from django.conf import settings
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_GET
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
@@ -85,7 +87,14 @@ def _requires_auth_submit(whisper):
 def _redirect_to_login(request):
     """Redirect to the login page, preserving the current URL as next."""
     login_url = getattr(settings, "LOGIN_URL", "/accounts/login/")
-    return redirect(f"{login_url}?next={request.get_full_path()}")
+    next_path = request.get_full_path()
+    if not url_has_allowed_host_and_scheme(
+        next_path,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
+        next_path = "/"
+    return redirect(f"{login_url}?{urlencode({'next': next_path})}")
 
 
 def _first_error(errors):


### PR DESCRIPTION
Potential fix for [https://github.com/ch0wm3in/psst-secret/security/code-scanning/3](https://github.com/ch0wm3in/psst-secret/security/code-scanning/3)

To fix this safely without changing intended behavior, stop constructing the redirect URL manually and only pass a validated local path as the `next` parameter.

Best approach in this file:
- Import `url_has_allowed_host_and_scheme` and `urlencode`.
- In `_redirect_to_login`, compute `next_path = request.get_full_path()`.
- Validate `next_path` with `url_has_allowed_host_and_scheme(..., allowed_hosts={request.get_host()}, require_https=request.is_secure())`.
- If invalid, fall back to `/`.
- Build the final URL as `f"{login_url}?{urlencode({'next': next_path})}"` to ensure safe encoding.
- Keep redirecting to configured `LOGIN_URL` as before.

This change is localized to `whispers/views.py` (imports and `_redirect_to_login`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
