### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/ch0wm3in/psst-secret/security/code-scanning/1](https://github.com/ch0wm3in/psst-secret/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/tests.yml` at the workflow root so it applies to all jobs (currently one job). The least-privilege baseline for this workflow is:

- `contents: read`

This preserves existing functionality (checkout + test execution) while ensuring `GITHUB_TOKEN` is constrained even if repository/org defaults change later.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
